### PR TITLE
Export browser file for module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   "files": [
     "dist"
   ],
-  "browser": "./dist/view-transitions-polyfill.js"
+  "browser": "./dist/view-transitions-polyfill.js",
+  "exports": {
+    ".": "./dist/view-transitions-polyfill.js"
+  }
 }


### PR DESCRIPTION
This ensures that depending on the package type,
require.resolve("view-transitions-polyfill")
import.meta.resolve("view-transitions-polyfill")
both return the correct file path.
"browser" is not a standard package.json field name.